### PR TITLE
fix(core): fix keyframes css key

### DIFF
--- a/packages/core/src/keyframes.ts
+++ b/packages/core/src/keyframes.ts
@@ -12,7 +12,7 @@ type Input = Record<string, CSSProperties>
 export function keyframes(input: Input, name?: string): string {
   const content = Object.entries(input).reduce<string>((result, [key, value]) => {
     const str = Object.entries(value).reduce<string>((r, [k, v]) => {
-      return r + `${k}: ${v};`
+      return r + `${jsKeyToCssKey(k)}: ${v};`
     }, '')
     return result + `${jsKeyToCssKey(key)} {${str}}`
   }, '')


### PR DESCRIPTION
修复 keyframes 没有正确转换 css key 的问题，比如以下代码执行时 `backgroundColor` 不会被转换成 `background-color`.

```js
keyframes({
  to: {
    backgroundColor: 'green',
  },
})
```